### PR TITLE
Chore: Expand readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# infrastructure
+# Infrastructure
 The infrastructure that runs the mindtastic backend
+
+## Setup
+
+### Requirements
+
+    brew install --cask google-cloud-sdk
+    brew install terraform
+
+## To run
+
+First, authenticate with Google Cloud
+
+    terraform init
+    terraform plan
+    terraform destroy
+
+## To test
+
+Exchange variable "google_container_cluster"


### PR DESCRIPTION
I want to try to run and setup these things locally as well. This PR is to collect and document how I would do it.
I added what I remembered from Wednesday maybe you can help expand/fix it a bit.

Questions:
Is it the "google_container_cluster" variable I have to exchange to run it with my own gcloud setup?
Did I forget anything glaringly obvious?