### PR TITLE
Add kubernetes-admin role to github teleport authenticator

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,10 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
   node_count = 1
 
   node_config {
-    preemptible  = true
+    preemptible = true
+    labels = {
+      environment = "production"
+    }
     machine_type = "e2-medium"
 
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.

--- a/modules/teleport/github.yaml
+++ b/modules/teleport/github.yaml
@@ -16,4 +16,4 @@ spec:
     - organization: ${teleport_github_org} # GitHub organization name
       team: admin            # GitHub team name within that organization
       # map GitHub's "admin" team to Teleport's "access" role
-      logins: ["access"]
+      logins: ["access", "k8s-admin"]

--- a/modules/teleport/helm.tf
+++ b/modules/teleport/helm.tf
@@ -49,6 +49,7 @@ resource "kubernetes_config_map" "github" {
   }
 
   data = {
+    "k8s-admin.yaml" = "${file("${path.module}/k8s-admin.yaml")}",
     "github.yaml" = "${templatefile("${path.module}/github.yaml", {
       teleport_github_client_id     = var.teleport_github_client_id
       teleport_github_client_secret = var.teleport_github_client_secret

--- a/modules/teleport/k8s-admin.yaml
+++ b/modules/teleport/k8s-admin.yaml
@@ -1,0 +1,9 @@
+kind: role
+version: v5
+metadata:
+  name: k8s-admin
+spec:
+  allow:
+    kubernetes_groups: ["system:masters"]
+    kubernetes_labels:
+      '*': '*'

--- a/modules/teleport/values.yaml
+++ b/modules/teleport/values.yaml
@@ -170,7 +170,7 @@ initContainers: []
 # If set, will run the command as a postStart handler
 # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
 postStart:
-  command: ["/bin/sh","-c","until tctl create -f /etc/teleport-github/github.yaml; do sleep 1; done"]
+  command: ["/bin/sh","-c","until tctl create -f /etc/teleport-github/k8s-admin.yaml && tctl create -f /etc/teleport-github/github.yaml; do sleep 1; done"]
 
 # Resources to request for each pod in the deployment
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/


### PR DESCRIPTION
All users from our github team will become kubernetes cluster admins. Fixes #29.
We want to have a more granular access model in the future (needs to be discussed)